### PR TITLE
Fix font-awesome import

### DIFF
--- a/src/components/base-components/select-control.html
+++ b/src/components/base-components/select-control.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../../3rd-imports/scoped-imd.html">
-<link rel="import" href="../../../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
+<link rel="import" href="../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
 
 <link rel="import" href="../../mixins/binding-helpers.html">
 <link rel="import" href="../../styling/control-bar--style-module.html">

--- a/src/components/control-bar/caption-control.html
+++ b/src/components/control-bar/caption-control.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../../3rd-imports/scoped-imd.html">
-<link rel="import" href="../../../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
+<link rel="import" href="../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
 
 <link rel="import" href="../../mixins/binding-helpers.html">
 <link rel="import" href="../../mixins/ioc-requester.html">

--- a/src/components/control-bar/full-screen-control.html
+++ b/src/components/control-bar/full-screen-control.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../../3rd-imports/scoped-imd.html">
-<link rel="import" href="../../../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
+<link rel="import" href="../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
 
 <link rel="import" href="../../mixins/binding-helpers.html">
 <link rel="import" href="../../mixins/ioc-requester.html">

--- a/src/components/control-bar/interactive-transcript-control.html
+++ b/src/components/control-bar/interactive-transcript-control.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../../3rd-imports/scoped-imd.html">
-<link rel="import" href="../../../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
+<link rel="import" href="../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
 
 <link rel="import" href="../../mixins/binding-helpers.html">
 <link rel="import" href="../../mixins/ioc-requester.html">

--- a/src/components/control-bar/mobile-settings-menu.html
+++ b/src/components/control-bar/mobile-settings-menu.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../../3rd-imports/scoped-imd.html">
-<link rel="import" href="../../../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
+<link rel="import" href="../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
 
 <link rel="import" href="../../mixins/binding-helpers.html">
 <link rel="import" href="../../mixins/ioc-requester.html">

--- a/src/components/control-bar/mute-control.html
+++ b/src/components/control-bar/mute-control.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../../3rd-imports/scoped-imd.html">
-<link rel="import" href="../../../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
+<link rel="import" href="../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
 
 <link rel="import" href="../../mixins/binding-helpers.html">
 <link rel="import" href="../../mixins/ioc-requester.html">

--- a/src/components/control-bar/playlist-chapter-list-switch.html
+++ b/src/components/control-bar/playlist-chapter-list-switch.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../../3rd-imports/scoped-imd.html">
-<link rel="import" href="../../../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
+<link rel="import" href="../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
 
 <link rel="import" href="../../mixins/binding-helpers.html">
 <link rel="import" href="../../mixins/ioc-requester.html">

--- a/src/components/control-bar/playlist-navigation-control.html
+++ b/src/components/control-bar/playlist-navigation-control.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../../3rd-imports/scoped-imd.html">
-<link rel="import" href="../../../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
+<link rel="import" href="../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
 
 <link rel="import" href="../../styling/control-bar--style-module.html">
 

--- a/src/components/control-bar/playpause-control.html
+++ b/src/components/control-bar/playpause-control.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../../3rd-imports/scoped-imd.html">
-<link rel="import" href="../../../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
+<link rel="import" href="../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
 <link rel="import" href="../../../../polymer/polymer-element.html">
 
 <link rel="import" href="../../constants.html">

--- a/src/components/control-bar/stream-switch-control.html
+++ b/src/components/control-bar/stream-switch-control.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../../3rd-imports/scoped-imd.html">
-<link rel="import" href="../../../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
+<link rel="import" href="../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
 <link rel="import" href="../../../../polymer/polymer-element.html">
 
 <link rel="import" href="../../mixins/binding-helpers.html">

--- a/src/components/interactive-transcript.html
+++ b/src/components/interactive-transcript.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../3rd-imports/scoped-imd.html">
-<link rel="import" href="../../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
+<link rel="import" href="../../node_modules/polymer-font-awesome/dist/font-awesome.html">
 
 <link rel="import" href="../mixins/binding-helpers.html">
 <link rel="import" href="../mixins/ioc-requester.html">

--- a/src/components/overlays/next-video-overlay.html
+++ b/src/components/overlays/next-video-overlay.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../../3rd-imports/scoped-imd.html">
-<link rel="import" href="../../../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
+<link rel="import" href="../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
 
 <link rel="import" href="../../mixins/binding-helpers.html">
 <link rel="import" href="../../mixins/ioc-requester.html">

--- a/src/components/playlist-chapter-list.html
+++ b/src/components/playlist-chapter-list.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../3rd-imports/scoped-imd.html">
-<link rel="import" href="../../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
+<link rel="import" href="../../node_modules/polymer-font-awesome/dist/font-awesome.html">
 
 <link rel="import" href="../mixins/binding-helpers.html">
 <link rel="import" href="../mixins/ioc-requester.html">

--- a/src/components/resizer-control.html
+++ b/src/components/resizer-control.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../3rd-imports/scoped-imd.html">
-<link rel="import" href="../../../../node_modules/polymer-font-awesome/dist/font-awesome.html">
+<link rel="import" href="../../node_modules/polymer-font-awesome/dist/font-awesome.html">
 
 <link rel="import" href="../mixins/binding-helpers.html">
 <link rel="import" href="../mixins/ioc-requester.html">

--- a/src/video-player.html
+++ b/src/video-player.html
@@ -366,7 +366,7 @@
         _configurationInitialized() {
           // Load FontAwesome, if specified in configuration
           if(this.configuration.loadFontAwesome) {
-            Polymer.importHref(this.importPath + '../../../node_modules/polymer-font-awesome/dist/font-face.html');
+            Polymer.importHref(this.importPath + '../node_modules/polymer-font-awesome/dist/font-face.html');
           }
 
           // In iOS playing multiple videos concurrently is currently not supported.


### PR DESCRIPTION
This PR will revert some of the changes of #39 in order to re-integrate font-awesome to the bundle. As mentioned in my previous PR, this slightly changes the file content when served with `polymer serve`, as it is not the intended way to access files from node_modules this way. 

Nevertheless, this will fix the problems with the bundle.