### PR TITLE
Prevent "this.api is undefined" error message if noteApi is not set and noteApiChanged is called.

### DIFF
--- a/src/services/indicator-manager.js
+++ b/src/services/indicator-manager.js
@@ -126,6 +126,8 @@ export class IndicatorManager{
    */
   noteApiChanged() {
     // Reload indicators from new api.
-    this.loadIndicators();
+    if(this.api) {
+      this.loadIndicators();
+    }
   }
 }


### PR DESCRIPTION
@malcm