### PR TITLE
Prevent TypeError in console

### DIFF
--- a/src/services/fullscreen-manager.js
+++ b/src/services/fullscreen-manager.js
@@ -55,7 +55,8 @@ export class FullscreenManager {
    */
   exitFullscreen() {
     if (document.exitFullscreen) {
-      document.exitFullscreen();
+      // Firefox likes to print a error message here. Prevent by providing own error handler.
+      document.exitFullscreen().catch(() => {});
     } else if (document.mozCancelFullScreen) {
       document.mozCancelFullScreen();
     } else if (document.webkitCancelFullScreen) {


### PR DESCRIPTION
Prevent "TypeError: The expression cannot be converted to return the specified type." on page load.